### PR TITLE
Fix typo, 'first' was used instead of 'second'

### DIFF
--- a/Part 3 - Taming the sequence/6. Hot and Cold observables.md
+++ b/Part 3 - Taming the sequence/6. Hot and Cold observables.md
@@ -161,7 +161,7 @@ Subscription s1 = cold.subscribe(i -> System.out.println("First: " + i));
 Thread.sleep(500);
 Subscription s2 = cold.subscribe(i -> System.out.println("Second: " + i));
 Thread.sleep(500);
-System.out.println("Unsubscribe first");
+System.out.println("Unsubscribe second");
 s2.unsubscribe();
 Thread.sleep(500);
 System.out.println("Unsubscribe first");
@@ -179,7 +179,7 @@ First: 2
 Second: 2
 First: 3
 Second: 3
-Unsubscribe first
+Unsubscribe second
 First: 4
 First: 5
 First: 6


### PR DESCRIPTION
In the `refcount` section, there was a two usage of the word first for identifying the subscriptions.Intro-To-RxJava